### PR TITLE
회원 가입 구현 및 SecurityConfig, Exception Handler 설정

### DIFF
--- a/src/main/java/com/e/commerce/domain/common/BaseEntity.java
+++ b/src/main/java/com/e/commerce/domain/common/BaseEntity.java
@@ -2,7 +2,6 @@ package com.e.commerce.domain.common;
 
 import java.time.LocalDateTime;
 
-import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -18,12 +17,10 @@ import lombok.Getter;
 public class BaseEntity {
 
 	@CreatedDate
-	@ColumnDefault("CURRENT_TIMESTAMP()")
 	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt = LocalDateTime.now();
 
 	@LastModifiedDate
-	@ColumnDefault("CURRENT_TIMESTAMP()")
 	@Column(name = "last_modified_at", nullable = false)
 	private LocalDateTime lastModifiedAt = LocalDateTime.now();
 }

--- a/src/main/java/com/e/commerce/domain/common/BaseEntity.java
+++ b/src/main/java/com/e/commerce/domain/common/BaseEntity.java
@@ -2,15 +2,14 @@ package com.e.commerce.domain.common;
 
 import java.time.LocalDateTime;
 
-import javax.persistence.Column;
-import javax.persistence.EntityListeners;
-import javax.persistence.MappedSuperclass;
-
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/e/commerce/domain/member/controller/RegisterController.java
+++ b/src/main/java/com/e/commerce/domain/member/controller/RegisterController.java
@@ -1,0 +1,31 @@
+package com.e.commerce.domain.member.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.e.commerce.domain.member.dto.RegisterRequest;
+import com.e.commerce.domain.member.service.MemberService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+public class RegisterController {
+	private final MemberService memberService;
+
+	@PostMapping("/register")
+	public ResponseEntity register(@RequestBody @Valid RegisterRequest request) {
+		Long savedMemberId = memberService.register(request);
+		log.info("Register Member Id : {}", savedMemberId);
+
+		return ResponseEntity.status(HttpStatus.CREATED).body(savedMemberId);
+	}
+}

--- a/src/main/java/com/e/commerce/domain/member/dto/RegisterRequest.java
+++ b/src/main/java/com/e/commerce/domain/member/dto/RegisterRequest.java
@@ -1,0 +1,34 @@
+package com.e.commerce.domain.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record RegisterRequest(
+	@NotNull(message = "아이디를 입력해주세요.")
+	@Size(min = 4, max = 12,
+		message = "4글자 이상 12글자 이하로 입력해주세요.")
+	@Pattern(regexp = "^[a-z0-9]+$",
+		message = "영문 소문자 및 숫자만 사용 가능합니다.")
+	String username,
+
+	@NotNull(message = "비밀번호를 입력해주세요.")
+	@Size(min = 8,
+		message = "최소 8자리 이상으로 설정해주세요.")
+	String password,
+
+	@NotNull(message = "이름을 입력해주세요.")
+	@Pattern(regexp = "^[가-힇a-zA-Z]+$",
+		message = "한글 또는 영문만 입력 가능합니다.")
+	String name,
+
+	@Pattern(regexp = "^([\\w-]+(?:\\.[\\w-]+)*)@((?:[\\w-]+\\.)*\\w[\\w-]{0,66})\\.([a-z]{2,6}(?:\\.[a-z]{2})?)$",
+		message = "올바른 이메일 형식을 입력해주세요.")
+	String email,
+
+	@NotNull(message = "전화번호를 입력해주세요.")
+	@Pattern(regexp = "^[0-9]{2,3}-[0-9]{3,4}-[0-9]{4}$",
+		message = "-를 포함하여 입력해주세요.")
+	String phoneNumber
+) {
+}

--- a/src/main/java/com/e/commerce/domain/member/entity/Member.java
+++ b/src/main/java/com/e/commerce/domain/member/entity/Member.java
@@ -1,0 +1,44 @@
+package com.e.commerce.domain.member.entity;
+
+import com.e.commerce.domain.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Member extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long memberId;
+
+	@Column(name = "username", nullable = false, unique = true)
+	private String username;
+
+	@Column(name = "password", nullable = false)
+	private String encryptedPassword;
+
+	@Column(name = "name", nullable = false)
+	private String name;
+
+	@Column(name = "email", unique = true)
+	private String email;
+
+	@Column(name = "phone_number", nullable = false, unique = true)
+	private String phoneNumber;
+
+	@Builder.Default
+	@Column(name = "point", nullable = false)
+	private Integer point = 0;
+}

--- a/src/main/java/com/e/commerce/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/e/commerce/domain/member/mapper/MemberMapper.java
@@ -1,0 +1,19 @@
+package com.e.commerce.domain.member.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import com.e.commerce.domain.member.dto.RegisterRequest;
+import com.e.commerce.domain.member.entity.Member;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface MemberMapper {
+
+	@Mapping(source = "request.username", target = "username")
+	@Mapping(source = "encryptedPassword", target = "encryptedPassword")
+	@Mapping(source = "request.name", target = "name")
+	@Mapping(source = "request.email", target = "email")
+	@Mapping(source = "request.phoneNumber", target = "phoneNumber")
+	Member toEntity(RegisterRequest request, String encryptedPassword);
+}

--- a/src/main/java/com/e/commerce/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/e/commerce/domain/member/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.e.commerce.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.e.commerce.domain.member.entity.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/e/commerce/domain/member/service/MemberService.java
+++ b/src/main/java/com/e/commerce/domain/member/service/MemberService.java
@@ -1,0 +1,27 @@
+package com.e.commerce.domain.member.service;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.e.commerce.domain.member.dto.RegisterRequest;
+import com.e.commerce.domain.member.entity.Member;
+import com.e.commerce.domain.member.mapper.MemberMapper;
+import com.e.commerce.domain.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+	private final PasswordEncoder passwordEncoder;
+	private final MemberMapper mapper;
+	private final MemberRepository repository;
+
+	public Long register(RegisterRequest request) {
+		String encryptedPassword = passwordEncoder.encode(request.password());
+		Member member = mapper.toEntity(request, encryptedPassword);
+		Member savedMember = repository.save(member);
+
+		return savedMember.getMemberId();
+	}
+}

--- a/src/main/java/com/e/commerce/global/exception/ErrorResponse.java
+++ b/src/main/java/com/e/commerce/global/exception/ErrorResponse.java
@@ -4,11 +4,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.validation.ConstraintViolation;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 
+import jakarta.validation.ConstraintViolation;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/e/commerce/global/exception/controller/GlobalExceptionAdvice.java
+++ b/src/main/java/com/e/commerce/global/exception/controller/GlobalExceptionAdvice.java
@@ -1,8 +1,7 @@
 package com.e.commerce.global.exception.controller;
 
-import javax.validation.ConstraintViolationException;
-
 import org.springframework.beans.TypeMismatchException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -17,6 +16,7 @@ import org.springframework.web.multipart.MultipartException;
 import com.e.commerce.global.exception.BusinessLogicException;
 import com.e.commerce.global.exception.ErrorResponse;
 
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -24,17 +24,19 @@ import lombok.extern.slf4j.Slf4j;
 public class GlobalExceptionAdvice {
 	@ExceptionHandler
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	public ErrorResponse handleMethodArgumentNotValidException(
-		MethodArgumentNotValidException e) {
+	public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
 		final ErrorResponse response = ErrorResponse.of(e.getBindingResult());
 
 		return response;
 	}
 
 	@ExceptionHandler({
-		IllegalStateException.class, IllegalArgumentException.class,
-		TypeMismatchException.class, HttpMessageNotReadableException.class,
-		MissingServletRequestParameterException.class, MultipartException.class,
+		IllegalStateException.class,
+		IllegalArgumentException.class,
+		TypeMismatchException.class,
+		HttpMessageNotReadableException.class,
+		MissingServletRequestParameterException.class,
+		MultipartException.class,
 	})
 	public ErrorResponse handleBadRequestException(Exception e) {
 		log.debug("Bad request exception occurred: {}", e.getMessage(), e);
@@ -54,6 +56,15 @@ public class GlobalExceptionAdvice {
 		final ErrorResponse response = ErrorResponse.of(e.getExceptionCode());
 
 		return new ResponseEntity<>(response, HttpStatus.valueOf(e.getExceptionCode().getCode()));
+	}
+
+	@ExceptionHandler
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ErrorResponse handleSQLIntegrityConstraintViolationException(DataIntegrityViolationException e) {
+		log.error("# handle Exception: {}", e.getMessage());
+		final ErrorResponse response = ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
+
+		return response;
 	}
 
 	@ExceptionHandler

--- a/src/main/java/com/e/commerce/global/security/SecurityConfiguration.java
+++ b/src/main/java/com/e/commerce/global/security/SecurityConfiguration.java
@@ -1,0 +1,34 @@
+package com.e.commerce.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfiguration {
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(auth -> {
+				auth.requestMatchers("/register").permitAll();
+				auth.requestMatchers("/auth/login").permitAll();
+			});
+
+		return http.build();
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+	}
+}


### PR DESCRIPTION
## 변경 사항
회원가입 로직 구현
- API : POST "/register"
- 유효성 검사
  - username : 영문 소문자 및 숫자로 구성된 4~12글자 (필수)
  - password : 8글자 이상 (필수)
  - name : 한글 또는 영문만 입력 (필수)
  - email : 형식에 맞게
  - phoneNumber : 전화번호 형식에 맞게 (필수)

Unique 값이 입력되면 핸들링 하도록 ExceptionHandler 추가

SecurityFilterChain의 CSRF 설정 Disable, 회원가입 및 로그인 접근 권한 설정